### PR TITLE
zh-Hans: Fix the i18n title for Simplified Chinese

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -65,7 +65,7 @@ export const languages = {
         ),
     },
     "zh-Hans": {
-        title: "首页",
+        title: "简体中文",
         messages: messages_zhhans,
         aboutHTML: fs.readFileSync(
             __dirname + "/../i18n/zh-Hans/about.html",


### PR DESCRIPTION
This PR fixes the language display name for Simplified Chinese.
|Before|After|
|---|---|
|首页（Home）|简体中文|